### PR TITLE
Update `actions/github-script` from v6 to v7

### DIFF
--- a/.github/workflows/track_fork_pr_benchmarks.yml
+++ b/.github/workflows/track_fork_pr_benchmarks.yml
@@ -14,7 +14,7 @@ jobs:
       PR_EVENT: event.json
     steps:
       - name: Download Benchmark Results
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             async function downloadArtifact(artifactName) {
@@ -45,7 +45,7 @@ jobs:
           unzip $BENCHMARK_RESULTS.zip
           unzip $PR_EVENT.zip
       - name: Export PR Event Data
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             let fs = require('fs');


### PR DESCRIPTION
Using v6 results in the following warning when the Action is run:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/github-script@v6. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

v7 of this action [uses Node 20 rather than 16](https://github.com/actions/github-script?tab=readme-ov-file#v7), and I don't think it's affected by any breaking changes between Node 16 and 20