### PR TITLE
Use --key/BENCHER_API_KEY instead of deprecated --token

### DIFF
--- a/.github/workflows/base_benchmarks.yml
+++ b/.github/workflows/base_benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           bencher run \
           --project example \
-          --token '${{ secrets.BENCHER_API_TOKEN }}' \
+          --key '${{ secrets.BENCHER_API_KEY }}' \
           --branch main \
           --testbed ubuntu-latest \
           --threshold-measure latency \

--- a/.github/workflows/fork_pr_benchmarks_closed.yml
+++ b/.github/workflows/fork_pr_benchmarks_closed.yml
@@ -13,5 +13,5 @@ jobs:
         run: |
           bencher archive \
           --project example \
-          --token '${{ secrets.BENCHER_API_TOKEN }}' \
+          --key '${{ secrets.BENCHER_API_KEY }}' \
           --branch "$GITHUB_HEAD_REF"

--- a/.github/workflows/fork_pr_benchmarks_track.yml
+++ b/.github/workflows/fork_pr_benchmarks_track.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           bencher run \
           --project example \
-          --token '${{ secrets.BENCHER_API_TOKEN }}' \
+          --key '${{ secrets.BENCHER_API_KEY }}' \
           --branch "$PR_HEAD" \
           --hash "$PR_HEAD_SHA" \
           --start-point "$PR_BASE" \

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -17,8 +17,8 @@ jobs:
         run: |
           bencher run \
           --project example \
-          --token '${{ secrets.BENCHER_API_TOKEN }}' \
-          --branch "$GITHUB_HEAD_REF"
+          --key '${{ secrets.BENCHER_API_KEY }}' \
+          --branch "$GITHUB_HEAD_REF" \
           --start-point "$GITHUB_BASE_REF" \
           --start-point-hash '${{ github.event.pull_request.base.sha }}' \
           --start-point-clone-thresholds \

--- a/.github/workflows/pr_benchmarks_closed.yml
+++ b/.github/workflows/pr_benchmarks_closed.yml
@@ -15,5 +15,5 @@ jobs:
         run: |
           bencher archive \
           --project example \
-          --token '${{ secrets.BENCHER_API_TOKEN }}' \
+          --key '${{ secrets.BENCHER_API_KEY }}' \
           --branch "$GITHUB_HEAD_REF"


### PR DESCRIPTION
## Summary

Bencher deprecated user API tokens in favor of API keys ([bencherdev/bencher#897](https://github.com/bencherdev/bencher/pull/897)), which is now deployed and released. This updates the example workflows to match the released convention.

- Swap `--token '${{ secrets.BENCHER_API_TOKEN }}'` → `--key '${{ secrets.BENCHER_API_KEY }}'` in all 5 authenticating workflows (`bencher run` / `bencher archive`):
  - `base_benchmarks.yml`
  - `fork_pr_benchmarks_closed.yml`
  - `fork_pr_benchmarks_track.yml`
  - `pr_benchmarks.yml`
  - `pr_benchmarks_closed.yml`
- Restore the missing line-continuation backslash on the `--branch "$GITHUB_HEAD_REF"` line in `pr_benchmarks.yml` so the command matches the canonical docs (pre-existing bug, not part of #897).

Verified the exact flag/secret convention against both the #897 diff and the live docs at https://bencher.dev/docs/how-to/github-actions/.

## Action required after merge

The secret name changed, so the workflows now reference `secrets.BENCHER_API_KEY`. Add a **`BENCHER_API_KEY`** repository secret (a project API key `bencher_run_*` is sufficient, since each workflow sets `--project example`). The old `BENCHER_API_TOKEN` secret can then be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)