### PR TITLE
Add checks: write permission to PR benchmark workflows

### DIFF
--- a/.github/workflows/fork_pr_benchmarks_track.yml
+++ b/.github/workflows/fork_pr_benchmarks_track.yml
@@ -9,6 +9,7 @@ jobs:
   track_fork_pr_branch:
     if: github.event.workflow_run.conclusion == 'success'
     permissions:
+      checks: write
       pull-requests: write
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/pr_benchmarks.yml
+++ b/.github/workflows/pr_benchmarks.yml
@@ -8,6 +8,7 @@ jobs:
     # DO NOT REMOVE: For handling Fork PRs see Pull Requests from Forks
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
+      checks: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

Match [bencherdev/bencher#895](https://github.com/bencherdev/bencher/pull/895), which makes `bencher run --github-actions` always create a `Bencher Report` GitHub Check (so it can gate branch protection as a required status check). Creating the check needs the `checks: write` permission.

Add `checks: write` alongside the existing `pull-requests: write` in the two workflows that run `bencher run --github-actions` on pull requests:

- `pr_benchmarks.yml`
- `fork_pr_benchmarks_track.yml`

This mirrors the canonical snippets updated in #895 (`pull-requests-code.mdx` and `pull-requests-fork-track-code.mdx`), with `checks: write` listed before `pull-requests: write`. `base_benchmarks.yml` already had `checks: write`; the closed/run workflows need no permissions block.

Note: the check is best-effort, so a missing `checks: write` only produces a warning rather than failing the run, but setting it is required for the Check to actually appear.